### PR TITLE
Fix: Trigger publish workflow for pre-releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,7 @@ on:
   release:
     types:
       - created
+      - prereleased
 
 jobs:
   publish:


### PR DESCRIPTION
## Summary
The publish workflow only triggers on `release: created` events, but GitHub fires `prereleased` (not `created`) for pre-releases. This caused the `1.0.0rc1` release to not publish to PyPI.

## Changes
- Add `prereleased` event type to the publish workflow trigger in `.github/workflows/publish.yml`