### PR TITLE
Fix: Revert pypa/gh-action-pypi-publish to v1.13.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,4 +23,4 @@ jobs:
         run: |
           uv build --verbose
       - name: Publish
-        uses: pypa/gh-action-pypi-publish@v1.14.0
+        uses: pypa/gh-action-pypi-publish@v1.13.0


### PR DESCRIPTION
## Summary
The `pypa/gh-action-pypi-publish` v1.14.0 Docker image is not published to ghcr.io yet, causing the publish workflow to fail with `manifest unknown`. This reverts to v1.13.0 which works.

## Changes
- Revert `pypa/gh-action-pypi-publish` from v1.14.0 to v1.13.0 in `.github/workflows/publish.yml`

The `1.0.0rc1` release needs to be re-triggered after this merges.