### PR TITLE
Fix: Default stateless=True in build_mcp_app and setup_mcp_subapp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `build_mcp_app()` and `setup_mcp_subapp()` now default to `stateless=True`, matching `AppBuilder` and documented behavior
+
 ### Added
 - Native MCP protocol implementation (`aiohttp_mcp/protocol/`) replacing the `mcp` SDK dependency
   - JSON-RPC 2.0 dispatch engine with full MCP method support

--- a/aiohttp_mcp/app.py
+++ b/aiohttp_mcp/app.py
@@ -70,7 +70,7 @@ def build_mcp_app(
     path: str = "/mcp",
     is_subapp: bool = False,
     json_response: bool = False,
-    stateless: bool = False,
+    stateless: bool = True,
 ) -> web.Application:
     """Build the MCP server application."""
     return AppBuilder(
@@ -87,7 +87,7 @@ def setup_mcp_subapp(
     prefix: str = "/mcp",
     package_names: list[str] | None = None,
     json_response: bool = False,
-    stateless: bool = False,
+    stateless: bool = True,
 ) -> None:
     """Set up the MCP server sub-application with the given prefix."""
     discover_modules(package_names)


### PR DESCRIPTION
## Summary
`build_mcp_app()` and `setup_mcp_subapp()` incorrectly defaulted to `stateless=False`, while `AppBuilder` defaults to `stateless=True` and the documentation states "Stateless by default".

## Changes
- `build_mcp_app()`: `stateless` parameter default changed from `False` to `True`
- `setup_mcp_subapp()`: `stateless` parameter default changed from `False` to `True`
- Added changelog entry under `[Unreleased] > Fixed`