### PR TITLE
Feature: Structured return types with outputSchema generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Structured return types**: Tools can now return Pydantic `BaseModel` or `dataclass` instances — they are automatically serialized to JSON via `TypeAdapter.dump_json()` instead of `str()`
+- **`outputSchema` generation**: Tools with `BaseModel` or `dataclass` return type annotations automatically populate `outputSchema` in `tools/list` responses (supported in MCP protocol 2025-06-18+)
+
 ### Fixed
 - `build_mcp_app()` and `setup_mcp_subapp()` now default to `stateless=True`, matching `AppBuilder` and documented behavior
+- Tools returning Pydantic models no longer produce ugly `str()` repr — they are serialized as proper JSON
 
 ### Added
 - Native MCP protocol implementation (`aiohttp_mcp/protocol/`) replacing the `mcp` SDK dependency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Structured return types**: Tools can now return Pydantic `BaseModel` or `dataclass` instances — they are automatically serialized to JSON via `TypeAdapter.dump_json()` instead of `str()`
-- **`outputSchema` generation**: Tools with `BaseModel` or `dataclass` return type annotations automatically populate `outputSchema` in `tools/list` responses (supported in MCP protocol 2025-06-18+)
-
-### Fixed
-- `build_mcp_app()` and `setup_mcp_subapp()` now default to `stateless=True`, matching `AppBuilder` and documented behavior
-- Tools returning Pydantic models no longer produce ugly `str()` repr — they are serialized as proper JSON
-
-### Added
+- **Structured return types**: Tools can now return Pydantic `BaseModel` or `dataclass` instances — they are automatically serialized to JSON via Pydantic's `TypeAdapter` instead of `str()`
+- **`outputSchema` generation**: Tools with return type annotations automatically populate `outputSchema` in `tools/list` responses (supported in MCP protocol 2025-06-18+)
 - Native MCP protocol implementation (`aiohttp_mcp/protocol/`) replacing the `mcp` SDK dependency
   - JSON-RPC 2.0 dispatch engine with full MCP method support
   - Tool, Resource, and Prompt registries with decorator-based registration
@@ -29,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Design document at `docs/native-mcp-implementation-plan.md`
 - Documentation policy in CLAUDE.md — code and docs ship together
 - MCPServer dispatch loop tests (18 tests, 87% server.py coverage)
+
+### Fixed
+- `build_mcp_app()` and `setup_mcp_subapp()` now default to `stateless=True`, matching `AppBuilder` and documented behavior
+- Tools returning Pydantic models or dataclasses no longer produce ugly `str()` repr — they are serialized as proper JSON
 
 ### Changed
 - **`stateless=True` is now the default** for `build_mcp_app()`, `setup_mcp_subapp()`, and `AppBuilder`. This is safer for multi-instance and load-balanced deployments. Use `stateless=False` to opt into stateful sessions (server push, event replay).

--- a/README.md
+++ b/README.md
@@ -224,6 +224,41 @@ async def deploy(service: str) -> str:
 
 This calls back into the resource registry using the same URI that MCP clients use — tools only need the URI, not a direct reference to the resource function.
 
+### Structured Return Types
+
+Tools can return Pydantic `BaseModel` or `dataclass` instances — they are automatically serialized to JSON and generate `outputSchema` in `tools/list` responses:
+
+```python
+import dataclasses
+from pydantic import BaseModel
+from aiohttp_mcp import AiohttpMCP
+
+mcp = AiohttpMCP()
+
+
+@dataclasses.dataclass
+class UserData:
+    name: str
+    email: str
+    age: int = 25
+
+
+class UserResult(BaseModel):
+    id: str
+    name: str
+    email: str
+
+
+@mcp.tool()
+async def create_user(data: UserData) -> UserResult:
+    """Create a new user."""
+    # Input: dataclass validated from dict/JSON automatically
+    # Output: BaseModel serialized to JSON, outputSchema auto-generated
+    return UserResult(id="123", name=data.name, email=data.email)
+```
+
+Plain types (`str`, `dict`, `list`) continue to work as before — `outputSchema` is only generated for `BaseModel` and `dataclass` return types.
+
 ### Client Example
 
 Here's how to create a client that interacts with the MCP server using the `mcp` client library:

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ async def create_user(data: UserData) -> UserResult:
     return UserResult(id="123", name=data.name, email=data.email)
 ```
 
-Plain types (`str`, `dict`, `list`) continue to work as before — `outputSchema` is only generated for `BaseModel` and `dataclass` return types.
+Plain types (`str`, `dict`, `list`) continue to serialize as before. `outputSchema` is generated for any return type annotation — `BaseModel` and `dataclass` return values additionally get proper JSON serialization via Pydantic's `TypeAdapter` instead of `str()`.
 
 ### Client Example
 

--- a/aiohttp_mcp/protocol/registry.py
+++ b/aiohttp_mcp/protocol/registry.py
@@ -455,6 +455,11 @@ def _build_output_adapter(fn: Callable[..., Any]) -> tuple[dict[str, Any] | None
     try:
         sig = inspect.signature(fn, eval_str=True)
     except (ValueError, TypeError):
+        logger.debug(
+            "Could not inspect signature of '%s' for outputSchema generation",
+            getattr(fn, "__qualname__", fn),
+            exc_info=True,
+        )
         return None, None
 
     annotation = sig.return_annotation
@@ -465,6 +470,12 @@ def _build_output_adapter(fn: Callable[..., Any]) -> tuple[dict[str, Any] | None
         adapter = TypeAdapter(annotation)
         schema = adapter.json_schema()
     except Exception:
+        logger.warning(
+            "Could not generate outputSchema for '%s' with return annotation %r",
+            getattr(fn, "__qualname__", fn),
+            annotation,
+            exc_info=True,
+        )
         return None, None
 
     # Only use adapter for serialization of structured types (BaseModel, dataclass).

--- a/aiohttp_mcp/protocol/registry.py
+++ b/aiohttp_mcp/protocol/registry.py
@@ -445,23 +445,35 @@ class Registry:
 
 
 def _build_output_adapter(fn: Callable[..., Any]) -> tuple[dict[str, Any] | None, TypeAdapter[Any] | None]:
-    """Inspect a function's return annotation and build a TypeAdapter if it's a BaseModel or dataclass."""
+    """Inspect a function's return annotation and build outputSchema + TypeAdapter.
+
+    Returns (output_schema, output_adapter) where:
+    - output_schema is generated for any return annotation (str, int, BaseModel, dataclass, etc.)
+    - output_adapter is only set for structured types (BaseModel, dataclass) that need
+      special serialization via TypeAdapter.dump_json()
+    """
     try:
         sig = inspect.signature(fn, eval_str=True)
     except (ValueError, TypeError):
         return None, None
 
     annotation = sig.return_annotation
-    if annotation is inspect.Parameter.empty:
+    if annotation is inspect.Parameter.empty or annotation is Any:
         return None, None
 
+    try:
+        adapter = TypeAdapter(annotation)
+        schema = adapter.json_schema()
+    except Exception:
+        return None, None
+
+    # Only use adapter for serialization of structured types (BaseModel, dataclass).
+    # Simple types (str, int, dict, list) are already handled by _convert_to_content.
     is_model = isinstance(annotation, type) and issubclass(annotation, BaseModel)
     is_dc = _dataclasses_module.is_dataclass(annotation) and isinstance(annotation, type)
-    if not (is_model or is_dc):
-        return None, None
+    serialization_adapter = adapter if (is_model or is_dc) else None
 
-    adapter = TypeAdapter(annotation)
-    return adapter.json_schema(), adapter
+    return schema, serialization_adapter
 
 
 _CONTENT_TYPES = (TextContent, ImageContent, AudioContent, EmbeddedResource, ResourceLink)

--- a/aiohttp_mcp/protocol/registry.py
+++ b/aiohttp_mcp/protocol/registry.py
@@ -4,6 +4,7 @@ Manages registration, listing, and execution of MCP primitives.
 Replaces FastMCP's internal tool/resource/prompt management.
 """
 
+import dataclasses as _dataclasses_module
 import inspect
 import json as _json_module
 import logging
@@ -12,7 +13,7 @@ from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
-from pydantic import AnyUrl
+from pydantic import AnyUrl, BaseModel, TypeAdapter
 
 from .context import Context, find_context_kwarg, get_current_context
 from .func_metadata import FuncMetadata, func_metadata
@@ -60,6 +61,8 @@ class ToolDef:
     context_kwarg: str | None
     annotations: ToolAnnotations | None = None
     icons: list[Icon] | None = None
+    output_schema: dict[str, Any] | None = None
+    output_adapter: TypeAdapter[Any] | None = None
 
 
 @dataclass
@@ -167,6 +170,8 @@ class Registry:
         meta_obj = func_metadata(fn, skip_names=skip_names)
         is_async = inspect.iscoroutinefunction(fn)
 
+        output_schema, output_adapter = _build_output_adapter(fn)
+
         self._tools[tool_name] = ToolDef(
             fn=fn,
             name=tool_name,
@@ -177,6 +182,8 @@ class Registry:
             context_kwarg=ctx_kwarg,
             annotations=annotations,
             icons=icons,
+            output_schema=output_schema,
+            output_adapter=output_adapter,
         )
 
     def remove_tool(self, name: str) -> None:
@@ -194,6 +201,7 @@ class Registry:
                     title=td.title,
                     description=td.description,
                     inputSchema=schema,
+                    outputSchema=td.output_schema,
                     icons=td.icons,
                     annotations=td.annotations,
                 )
@@ -224,6 +232,10 @@ class Registry:
             raise
         except Exception as e:
             raise ToolError(str(e)) from e
+
+        if td.output_adapter is not None and not isinstance(result, (str, dict, list, *_CONTENT_TYPES)):
+            json_bytes = td.output_adapter.dump_json(result)
+            return [TextContent(text=json_bytes.decode())]
 
         return _convert_to_content(result)
 
@@ -430,6 +442,26 @@ class Registry:
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+def _build_output_adapter(fn: Callable[..., Any]) -> tuple[dict[str, Any] | None, TypeAdapter[Any] | None]:
+    """Inspect a function's return annotation and build a TypeAdapter if it's a BaseModel or dataclass."""
+    try:
+        sig = inspect.signature(fn, eval_str=True)
+    except (ValueError, TypeError):
+        return None, None
+
+    annotation = sig.return_annotation
+    if annotation is inspect.Parameter.empty:
+        return None, None
+
+    is_model = isinstance(annotation, type) and issubclass(annotation, BaseModel)
+    is_dc = _dataclasses_module.is_dataclass(annotation) and isinstance(annotation, type)
+    if not (is_model or is_dc):
+        return None, None
+
+    adapter = TypeAdapter(annotation)
+    return adapter.json_schema(), adapter
 
 
 _CONTENT_TYPES = (TextContent, ImageContent, AudioContent, EmbeddedResource, ResourceLink)

--- a/aiohttp_mcp/protocol/registry.py
+++ b/aiohttp_mcp/protocol/registry.py
@@ -497,5 +497,9 @@ def _single_to_content(item: Any) -> Content:
         return TextContent(text=item)
     if isinstance(item, dict):
         return TextContent(text=_json_module.dumps(item))
+    if isinstance(item, BaseModel):
+        return TextContent(text=item.model_dump_json())
+    if _dataclasses_module.is_dataclass(item) and not isinstance(item, type):
+        return TextContent(text=TypeAdapter(type(item)).dump_json(item).decode())
 
     return TextContent(text=str(item))

--- a/aiohttp_mcp/protocol/registry.py
+++ b/aiohttp_mcp/protocol/registry.py
@@ -234,7 +234,10 @@ class Registry:
             raise ToolError(str(e)) from e
 
         if td.output_adapter is not None and not isinstance(result, (str, dict, list, *_CONTENT_TYPES)):
-            json_bytes = td.output_adapter.dump_json(result)
+            try:
+                json_bytes = td.output_adapter.dump_json(result)
+            except Exception as e:
+                raise ToolError(f"Failed to serialize tool output: {e}") from e
             return [TextContent(text=json_bytes.decode())]
 
         return _convert_to_content(result)

--- a/aiohttp_mcp/protocol/registry.py
+++ b/aiohttp_mcp/protocol/registry.py
@@ -4,7 +4,7 @@ Manages registration, listing, and execution of MCP primitives.
 Replaces FastMCP's internal tool/resource/prompt management.
 """
 
-import dataclasses as _dataclasses_module
+import dataclasses
 import inspect
 import json as _json_module
 import logging
@@ -484,7 +484,7 @@ def _build_output_adapter(fn: Callable[..., Any]) -> tuple[dict[str, Any] | None
     # Only use adapter for serialization of structured types (BaseModel, dataclass).
     # Simple types (str, int, dict, list) are already handled by _convert_to_content.
     is_model = isinstance(annotation, type) and issubclass(annotation, BaseModel)
-    is_dc = _dataclasses_module.is_dataclass(annotation) and isinstance(annotation, type)
+    is_dc = dataclasses.is_dataclass(annotation) and isinstance(annotation, type)
     serialization_adapter = adapter if (is_model or is_dc) else None
 
     return schema, serialization_adapter
@@ -513,7 +513,7 @@ def _single_to_content(item: Any) -> Content:
         return TextContent(text=_json_module.dumps(item))
     if isinstance(item, BaseModel):
         return TextContent(text=item.model_dump_json())
-    if _dataclasses_module.is_dataclass(item) and not isinstance(item, type):
+    if dataclasses.is_dataclass(item) and not isinstance(item, type):
         return TextContent(text=TypeAdapter(type(item)).dump_json(item).decode())
 
     return TextContent(text=str(item))

--- a/tests/test_output_schema.py
+++ b/tests/test_output_schema.py
@@ -2,12 +2,15 @@
 
 import dataclasses
 import json
+from collections.abc import Callable
 from typing import Any
 
+import pytest
 from pydantic import BaseModel
 
 from aiohttp_mcp import AiohttpMCP
 from aiohttp_mcp.protocol.models import TextContent
+from aiohttp_mcp.protocol.registry import ToolError, _build_output_adapter
 
 # -- Test models --
 
@@ -231,6 +234,42 @@ class TestOutputSchemaGeneration:
 def _no_annotation_tool(msg: str):  # type: ignore[no-untyped-def]
     """Tool without return annotation — defined at module level to avoid mypy error."""
     return msg
+
+
+# -- Tests: error paths --
+
+
+class TestErrorPaths:
+    """Test error/failure paths in _build_output_adapter and call_tool serialization."""
+
+    async def test_uninspectable_function_returns_no_schema(self) -> None:
+        """Functions whose signature can't be inspected should return (None, None)."""
+        # Built-in functions raise ValueError from inspect.signature
+        schema, adapter = _build_output_adapter(len)
+        assert schema is None
+        assert adapter is None
+
+    async def test_unsupported_annotation_returns_no_schema(self) -> None:
+        """Annotations that TypeAdapter can't handle should return (None, None)."""
+
+        # Bare Callable without args is not schema-able
+        def tool_fn() -> Callable:  # type: ignore[type-arg,empty-body]
+            pass
+
+        schema, adapter = _build_output_adapter(tool_fn)
+        assert schema is None
+        assert adapter is None
+
+    async def test_dump_json_failure_raises_tool_error(self) -> None:
+        """If dump_json fails at runtime, it should raise ToolError, not internal error."""
+        mcp = AiohttpMCP()
+
+        @mcp.tool()
+        def get_user() -> UserModel:
+            return object()  # type: ignore[return-value]
+
+        with pytest.raises(ToolError, match="Failed to serialize tool output"):
+            await mcp.call_tool("get_user", {})
 
 
 # -- Tests: serialization --

--- a/tests/test_output_schema.py
+++ b/tests/test_output_schema.py
@@ -398,3 +398,73 @@ class TestBackwardCompatibility:
         content = result[0]
         assert isinstance(content, TextContent)
         assert json.loads(content.text) == {"name": "Alice", "email": "a@b.com"}
+
+    async def test_optional_basemodel_return_serialized(self) -> None:
+        """Optional[BaseModel] should serialize the model to JSON, not str() repr."""
+        mcp = AiohttpMCP()
+
+        @mcp.tool()
+        def get_user() -> UserModel | None:
+            return UserModel(name="Alice", email="a@b.com")
+
+        result = await mcp.call_tool("get_user", {})
+        assert len(result) == 1
+        content = result[0]
+        assert isinstance(content, TextContent)
+        assert json.loads(content.text) == {"name": "Alice", "email": "a@b.com"}
+
+    async def test_optional_basemodel_return_none(self) -> None:
+        """Optional[BaseModel] returning None should work."""
+        mcp = AiohttpMCP()
+
+        @mcp.tool()
+        def get_user() -> UserModel | None:
+            return None
+
+        result = await mcp.call_tool("get_user", {})
+        assert len(result) == 1
+        content = result[0]
+        assert isinstance(content, TextContent)
+        assert content.text == "None"
+
+    async def test_optional_dataclass_return_serialized(self) -> None:
+        """Optional[dataclass] should serialize the dataclass to JSON."""
+        mcp = AiohttpMCP()
+
+        @mcp.tool()
+        def get_user() -> UserDC | None:
+            return UserDC(name="Bob", email="b@b.com")
+
+        result = await mcp.call_tool("get_user", {})
+        assert len(result) == 1
+        content = result[0]
+        assert isinstance(content, TextContent)
+        assert json.loads(content.text) == {"name": "Bob", "email": "b@b.com"}
+
+    async def test_list_basemodel_return_serialized(self) -> None:
+        """list[BaseModel] should serialize each model to JSON."""
+        mcp = AiohttpMCP()
+
+        @mcp.tool()
+        def get_users() -> list[UserModel]:
+            return [UserModel(name="Alice", email="a@b.com"), UserModel(name="Bob", email="b@b.com")]
+
+        result = await mcp.call_tool("get_users", {})
+        assert len(result) == 2
+        assert all(isinstance(c, TextContent) for c in result)
+        assert json.loads(result[0].text) == {"name": "Alice", "email": "a@b.com"}  # type: ignore[union-attr]
+        assert json.loads(result[1].text) == {"name": "Bob", "email": "b@b.com"}  # type: ignore[union-attr]
+
+    async def test_tool_returning_content_type_with_model_annotation(self) -> None:
+        """If the tool has a model annotation but returns a Content type, it should pass through."""
+        mcp = AiohttpMCP()
+
+        @mcp.tool()
+        def get_user() -> UserModel:
+            return TextContent(text="custom")  # type: ignore[return-value]
+
+        result = await mcp.call_tool("get_user", {})
+        assert len(result) == 1
+        content = result[0]
+        assert isinstance(content, TextContent)
+        assert content.text == "custom"

--- a/tests/test_output_schema.py
+++ b/tests/test_output_schema.py
@@ -94,7 +94,7 @@ class TestOutputSchemaGeneration:
         assert "user" in schema["properties"]
         assert "$defs" in schema or "definitions" in schema or "$ref" in schema["properties"]["user"]
 
-    async def test_str_return_no_output_schema(self) -> None:
+    async def test_str_return_generates_output_schema(self) -> None:
         mcp = AiohttpMCP()
 
         @mcp.tool()
@@ -102,17 +102,63 @@ class TestOutputSchemaGeneration:
             return msg
 
         tools = await mcp.list_tools()
-        assert tools[0].outputSchema is None
+        assert tools[0].outputSchema is not None
+        assert tools[0].outputSchema["type"] == "string"
 
-    async def test_dict_return_no_output_schema(self) -> None:
+    async def test_int_return_generates_output_schema(self) -> None:
         mcp = AiohttpMCP()
 
         @mcp.tool()
-        def echo() -> dict[str, str]:
-            return {"key": "value"}
+        def count() -> int:
+            return 42
 
         tools = await mcp.list_tools()
-        assert tools[0].outputSchema is None
+        assert tools[0].outputSchema is not None
+        assert tools[0].outputSchema["type"] == "integer"
+
+    async def test_bool_return_generates_output_schema(self) -> None:
+        mcp = AiohttpMCP()
+
+        @mcp.tool()
+        def check() -> bool:
+            return True
+
+        tools = await mcp.list_tools()
+        assert tools[0].outputSchema is not None
+        assert tools[0].outputSchema["type"] == "boolean"
+
+    async def test_list_return_generates_output_schema(self) -> None:
+        mcp = AiohttpMCP()
+
+        @mcp.tool()
+        def items() -> list[str]:
+            return ["a", "b"]
+
+        tools = await mcp.list_tools()
+        assert tools[0].outputSchema is not None
+        assert tools[0].outputSchema["type"] == "array"
+
+    async def test_dict_return_generates_output_schema(self) -> None:
+        mcp = AiohttpMCP()
+
+        @mcp.tool()
+        def data() -> dict[str, int]:
+            return {"key": 1}
+
+        tools = await mcp.list_tools()
+        assert tools[0].outputSchema is not None
+        assert tools[0].outputSchema["type"] == "object"
+
+    async def test_optional_return_generates_output_schema(self) -> None:
+        mcp = AiohttpMCP()
+
+        @mcp.tool()
+        def maybe() -> str | None:
+            return None
+
+        tools = await mcp.list_tools()
+        assert tools[0].outputSchema is not None
+        assert "anyOf" in tools[0].outputSchema
 
     async def test_no_return_annotation_no_output_schema(self) -> None:
         mcp = AiohttpMCP()

--- a/tests/test_output_schema.py
+++ b/tests/test_output_schema.py
@@ -7,7 +7,6 @@ from pydantic import BaseModel
 from aiohttp_mcp import AiohttpMCP
 from aiohttp_mcp.protocol.models import TextContent
 
-
 # -- Test models --
 
 

--- a/tests/test_output_schema.py
+++ b/tests/test_output_schema.py
@@ -2,6 +2,7 @@
 
 import dataclasses
 import json
+from typing import Any
 
 from pydantic import BaseModel
 
@@ -197,6 +198,26 @@ class TestOutputSchemaGeneration:
         assert tools[0].outputSchema == {
             "anyOf": [{"type": "string"}, {"type": "null"}],
         }
+
+    async def test_any_return_no_output_schema(self) -> None:
+        mcp = AiohttpMCP()
+
+        @mcp.tool()
+        def anything() -> Any:
+            return "whatever"
+
+        tools = await mcp.list_tools()
+        assert tools[0].outputSchema is None
+
+    async def test_none_return_generates_output_schema(self) -> None:
+        mcp = AiohttpMCP()
+
+        @mcp.tool()
+        def noop() -> None:
+            pass
+
+        tools = await mcp.list_tools()
+        assert tools[0].outputSchema == {"type": "null"}
 
     async def test_no_return_annotation_no_output_schema(self) -> None:
         mcp = AiohttpMCP()

--- a/tests/test_output_schema.py
+++ b/tests/test_output_schema.py
@@ -1,6 +1,7 @@
 """Tests for structured return types (BaseModel, dataclass) and outputSchema generation."""
 
 import dataclasses
+import json
 
 from pydantic import BaseModel
 
@@ -48,11 +49,16 @@ class TestOutputSchemaGeneration:
 
         tools = await mcp.list_tools()
         assert len(tools) == 1
-        assert tools[0].outputSchema is not None
         schema = tools[0].outputSchema
-        assert schema["type"] == "object"
-        assert "name" in schema["properties"]
-        assert "email" in schema["properties"]
+        assert schema == {
+            "properties": {
+                "name": {"title": "Name", "type": "string"},
+                "email": {"title": "Email", "type": "string"},
+            },
+            "required": ["name", "email"],
+            "title": "UserModel",
+            "type": "object",
+        }
 
     async def test_dataclass_return_generates_output_schema(self) -> None:
         mcp = AiohttpMCP()
@@ -63,11 +69,16 @@ class TestOutputSchemaGeneration:
 
         tools = await mcp.list_tools()
         assert len(tools) == 1
-        assert tools[0].outputSchema is not None
         schema = tools[0].outputSchema
-        assert schema["type"] == "object"
-        assert "name" in schema["properties"]
-        assert "email" in schema["properties"]
+        assert schema == {
+            "properties": {
+                "name": {"title": "Name", "type": "string"},
+                "email": {"title": "Email", "type": "string"},
+            },
+            "required": ["name", "email"],
+            "title": "UserDC",
+            "type": "object",
+        }
 
     async def test_dataclass_with_defaults_in_schema(self) -> None:
         mcp = AiohttpMCP()
@@ -79,7 +90,10 @@ class TestOutputSchemaGeneration:
         tools = await mcp.list_tools()
         schema = tools[0].outputSchema
         assert schema is not None
-        assert schema["properties"]["age"]["default"] == 25
+        assert schema["properties"]["name"] == {"title": "Name", "type": "string"}
+        assert schema["properties"]["email"] == {"title": "Email", "type": "string"}
+        assert schema["properties"]["age"] == {"default": 25, "title": "Age", "type": "integer"}
+        assert schema["required"] == ["name", "email"]
 
     async def test_nested_model_generates_output_schema(self) -> None:
         mcp = AiohttpMCP()
@@ -91,8 +105,20 @@ class TestOutputSchemaGeneration:
         tools = await mcp.list_tools()
         schema = tools[0].outputSchema
         assert schema is not None
-        assert "user" in schema["properties"]
-        assert "$defs" in schema or "definitions" in schema or "$ref" in schema["properties"]["user"]
+        assert schema["type"] == "object"
+        assert schema["required"] == ["user", "role"]
+        assert schema["properties"]["role"] == {"title": "Role", "type": "string"}
+        assert schema["properties"]["user"] == {"$ref": "#/$defs/UserModel"}
+        assert "$defs" in schema
+        assert schema["$defs"]["UserModel"] == {
+            "properties": {
+                "name": {"title": "Name", "type": "string"},
+                "email": {"title": "Email", "type": "string"},
+            },
+            "required": ["name", "email"],
+            "title": "UserModel",
+            "type": "object",
+        }
 
     async def test_str_return_generates_output_schema(self) -> None:
         mcp = AiohttpMCP()
@@ -102,8 +128,7 @@ class TestOutputSchemaGeneration:
             return msg
 
         tools = await mcp.list_tools()
-        assert tools[0].outputSchema is not None
-        assert tools[0].outputSchema["type"] == "string"
+        assert tools[0].outputSchema == {"type": "string"}
 
     async def test_int_return_generates_output_schema(self) -> None:
         mcp = AiohttpMCP()
@@ -113,8 +138,7 @@ class TestOutputSchemaGeneration:
             return 42
 
         tools = await mcp.list_tools()
-        assert tools[0].outputSchema is not None
-        assert tools[0].outputSchema["type"] == "integer"
+        assert tools[0].outputSchema == {"type": "integer"}
 
     async def test_bool_return_generates_output_schema(self) -> None:
         mcp = AiohttpMCP()
@@ -124,8 +148,17 @@ class TestOutputSchemaGeneration:
             return True
 
         tools = await mcp.list_tools()
-        assert tools[0].outputSchema is not None
-        assert tools[0].outputSchema["type"] == "boolean"
+        assert tools[0].outputSchema == {"type": "boolean"}
+
+    async def test_float_return_generates_output_schema(self) -> None:
+        mcp = AiohttpMCP()
+
+        @mcp.tool()
+        def measure() -> float:
+            return 3.14
+
+        tools = await mcp.list_tools()
+        assert tools[0].outputSchema == {"type": "number"}
 
     async def test_list_return_generates_output_schema(self) -> None:
         mcp = AiohttpMCP()
@@ -135,8 +168,10 @@ class TestOutputSchemaGeneration:
             return ["a", "b"]
 
         tools = await mcp.list_tools()
-        assert tools[0].outputSchema is not None
-        assert tools[0].outputSchema["type"] == "array"
+        assert tools[0].outputSchema == {
+            "items": {"type": "string"},
+            "type": "array",
+        }
 
     async def test_dict_return_generates_output_schema(self) -> None:
         mcp = AiohttpMCP()
@@ -146,8 +181,10 @@ class TestOutputSchemaGeneration:
             return {"key": 1}
 
         tools = await mcp.list_tools()
-        assert tools[0].outputSchema is not None
-        assert tools[0].outputSchema["type"] == "object"
+        assert tools[0].outputSchema == {
+            "additionalProperties": {"type": "integer"},
+            "type": "object",
+        }
 
     async def test_optional_return_generates_output_schema(self) -> None:
         mcp = AiohttpMCP()
@@ -157,8 +194,9 @@ class TestOutputSchemaGeneration:
             return None
 
         tools = await mcp.list_tools()
-        assert tools[0].outputSchema is not None
-        assert "anyOf" in tools[0].outputSchema
+        assert tools[0].outputSchema == {
+            "anyOf": [{"type": "string"}, {"type": "null"}],
+        }
 
     async def test_no_return_annotation_no_output_schema(self) -> None:
         mcp = AiohttpMCP()
@@ -191,8 +229,7 @@ class TestStructuredReturnSerialization:
         assert len(result) == 1
         content = result[0]
         assert isinstance(content, TextContent)
-        assert '"name":"Alice"' in content.text or '"name": "Alice"' in content.text
-        assert '"email":"a@b.com"' in content.text or '"email": "a@b.com"' in content.text
+        assert json.loads(content.text) == {"name": "Alice", "email": "a@b.com"}
 
     async def test_dataclass_return_serialized_to_json(self) -> None:
         mcp = AiohttpMCP()
@@ -205,8 +242,34 @@ class TestStructuredReturnSerialization:
         assert len(result) == 1
         content = result[0]
         assert isinstance(content, TextContent)
-        assert '"name":"Bob"' in content.text or '"name": "Bob"' in content.text
-        assert '"email":"b@b.com"' in content.text or '"email": "b@b.com"' in content.text
+        assert json.loads(content.text) == {"name": "Bob", "email": "b@b.com"}
+
+    async def test_dataclass_with_defaults_serialized(self) -> None:
+        mcp = AiohttpMCP()
+
+        @mcp.tool()
+        def get_user() -> UserDCWithDefaults:
+            return UserDCWithDefaults(name="Alice", email="a@b.com")
+
+        result = await mcp.call_tool("get_user", {})
+        content = result[0]
+        assert isinstance(content, TextContent)
+        assert json.loads(content.text) == {"name": "Alice", "email": "a@b.com", "age": 25}
+
+    async def test_nested_model_serialized_to_json(self) -> None:
+        mcp = AiohttpMCP()
+
+        @mcp.tool()
+        def get_admin() -> NestedModel:
+            return NestedModel(user=UserModel(name="Alice", email="a@b.com"), role="admin")
+
+        result = await mcp.call_tool("get_admin", {})
+        content = result[0]
+        assert isinstance(content, TextContent)
+        assert json.loads(content.text) == {
+            "user": {"name": "Alice", "email": "a@b.com"},
+            "role": "admin",
+        }
 
     async def test_basemodel_not_str_repr(self) -> None:
         """Ensure BaseModel is not serialized via str() which produces a repr."""
@@ -244,10 +307,23 @@ class TestStructuredReturnSerialization:
             return UserModel(name="Async", email="async@b.com")
 
         result = await mcp.call_tool("get_user", {})
+        assert len(result) == 1
         content = result[0]
         assert isinstance(content, TextContent)
-        assert "Async" in content.text
-        assert "async@b.com" in content.text
+        assert json.loads(content.text) == {"name": "Async", "email": "async@b.com"}
+
+    async def test_async_tool_with_dataclass_return(self) -> None:
+        mcp = AiohttpMCP()
+
+        @mcp.tool()
+        async def get_user() -> UserDC:
+            return UserDC(name="Async", email="async@b.com")
+
+        result = await mcp.call_tool("get_user", {})
+        assert len(result) == 1
+        content = result[0]
+        assert isinstance(content, TextContent)
+        assert json.loads(content.text) == {"name": "Async", "email": "async@b.com"}
 
 
 # -- Tests: backward compatibility --
@@ -264,7 +340,10 @@ class TestBackwardCompatibility:
             return msg
 
         result = await mcp.call_tool("echo", {"msg": "hello"})
-        assert result[0].text == "hello"  # type: ignore[union-attr]
+        assert len(result) == 1
+        content = result[0]
+        assert isinstance(content, TextContent)
+        assert content.text == "hello"
 
     async def test_dict_return_unchanged(self) -> None:
         mcp = AiohttpMCP()
@@ -274,7 +353,10 @@ class TestBackwardCompatibility:
             return {"key": "value"}
 
         result = await mcp.call_tool("data", {})
-        assert '"key"' in result[0].text  # type: ignore[union-attr]
+        assert len(result) == 1
+        content = result[0]
+        assert isinstance(content, TextContent)
+        assert json.loads(content.text) == {"key": "value"}
 
     async def test_list_return_unchanged(self) -> None:
         mcp = AiohttpMCP()
@@ -285,6 +367,9 @@ class TestBackwardCompatibility:
 
         result = await mcp.call_tool("items", {})
         assert len(result) == 2
+        assert all(isinstance(c, TextContent) for c in result)
+        assert result[0].text == "a"  # type: ignore[union-attr]
+        assert result[1].text == "b"  # type: ignore[union-attr]
 
     async def test_tool_returning_str_even_with_model_annotation(self) -> None:
         """If the tool has a model annotation but returns a string, it should still work."""
@@ -295,7 +380,21 @@ class TestBackwardCompatibility:
             return "raw string fallback"  # type: ignore[return-value]
 
         result = await mcp.call_tool("get_user", {})
+        assert len(result) == 1
         content = result[0]
         assert isinstance(content, TextContent)
-        # str is caught before the adapter path
         assert content.text == "raw string fallback"
+
+    async def test_tool_returning_dict_even_with_model_annotation(self) -> None:
+        """If the tool has a model annotation but returns a dict, it should still work."""
+        mcp = AiohttpMCP()
+
+        @mcp.tool()
+        def get_user() -> UserModel:
+            return {"name": "Alice", "email": "a@b.com"}  # type: ignore[return-value]
+
+        result = await mcp.call_tool("get_user", {})
+        assert len(result) == 1
+        content = result[0]
+        assert isinstance(content, TextContent)
+        assert json.loads(content.text) == {"name": "Alice", "email": "a@b.com"}

--- a/tests/test_output_schema.py
+++ b/tests/test_output_schema.py
@@ -1,0 +1,256 @@
+"""Tests for structured return types (BaseModel, dataclass) and outputSchema generation."""
+
+import dataclasses
+
+from pydantic import BaseModel
+
+from aiohttp_mcp import AiohttpMCP
+from aiohttp_mcp.protocol.models import TextContent
+
+
+# -- Test models --
+
+
+class UserModel(BaseModel):
+    name: str
+    email: str
+
+
+class NestedModel(BaseModel):
+    user: UserModel
+    role: str
+
+
+@dataclasses.dataclass
+class UserDC:
+    name: str
+    email: str
+
+
+@dataclasses.dataclass
+class UserDCWithDefaults:
+    name: str
+    email: str
+    age: int = 25
+
+
+# -- Tests: outputSchema generation --
+
+
+class TestOutputSchemaGeneration:
+    """Test that outputSchema is generated from return type annotations."""
+
+    async def test_basemodel_return_generates_output_schema(self) -> None:
+        mcp = AiohttpMCP()
+
+        @mcp.tool()
+        def get_user(user_id: str) -> UserModel:
+            return UserModel(name="Alice", email="a@b.com")
+
+        tools = await mcp.list_tools()
+        assert len(tools) == 1
+        assert tools[0].outputSchema is not None
+        schema = tools[0].outputSchema
+        assert schema["type"] == "object"
+        assert "name" in schema["properties"]
+        assert "email" in schema["properties"]
+
+    async def test_dataclass_return_generates_output_schema(self) -> None:
+        mcp = AiohttpMCP()
+
+        @mcp.tool()
+        def get_user(user_id: str) -> UserDC:
+            return UserDC(name="Alice", email="a@b.com")
+
+        tools = await mcp.list_tools()
+        assert len(tools) == 1
+        assert tools[0].outputSchema is not None
+        schema = tools[0].outputSchema
+        assert schema["type"] == "object"
+        assert "name" in schema["properties"]
+        assert "email" in schema["properties"]
+
+    async def test_dataclass_with_defaults_in_schema(self) -> None:
+        mcp = AiohttpMCP()
+
+        @mcp.tool()
+        def get_user() -> UserDCWithDefaults:
+            return UserDCWithDefaults(name="Alice", email="a@b.com")
+
+        tools = await mcp.list_tools()
+        schema = tools[0].outputSchema
+        assert schema is not None
+        assert schema["properties"]["age"]["default"] == 25
+
+    async def test_nested_model_generates_output_schema(self) -> None:
+        mcp = AiohttpMCP()
+
+        @mcp.tool()
+        def get_admin() -> NestedModel:
+            return NestedModel(user=UserModel(name="Alice", email="a@b.com"), role="admin")
+
+        tools = await mcp.list_tools()
+        schema = tools[0].outputSchema
+        assert schema is not None
+        assert "user" in schema["properties"]
+        assert "$defs" in schema or "definitions" in schema or "$ref" in schema["properties"]["user"]
+
+    async def test_str_return_no_output_schema(self) -> None:
+        mcp = AiohttpMCP()
+
+        @mcp.tool()
+        def echo(msg: str) -> str:
+            return msg
+
+        tools = await mcp.list_tools()
+        assert tools[0].outputSchema is None
+
+    async def test_dict_return_no_output_schema(self) -> None:
+        mcp = AiohttpMCP()
+
+        @mcp.tool()
+        def echo() -> dict[str, str]:
+            return {"key": "value"}
+
+        tools = await mcp.list_tools()
+        assert tools[0].outputSchema is None
+
+    async def test_no_return_annotation_no_output_schema(self) -> None:
+        mcp = AiohttpMCP()
+
+        mcp.add_tool(_no_annotation_tool)
+
+        tools = await mcp.list_tools()
+        assert tools[0].outputSchema is None
+
+
+def _no_annotation_tool(msg: str):  # type: ignore[no-untyped-def]
+    """Tool without return annotation — defined at module level to avoid mypy error."""
+    return msg
+
+
+# -- Tests: serialization --
+
+
+class TestStructuredReturnSerialization:
+    """Test that BaseModel and dataclass return values are serialized to JSON."""
+
+    async def test_basemodel_return_serialized_to_json(self) -> None:
+        mcp = AiohttpMCP()
+
+        @mcp.tool()
+        def get_user() -> UserModel:
+            return UserModel(name="Alice", email="a@b.com")
+
+        result = await mcp.call_tool("get_user", {})
+        assert len(result) == 1
+        content = result[0]
+        assert isinstance(content, TextContent)
+        assert '"name":"Alice"' in content.text or '"name": "Alice"' in content.text
+        assert '"email":"a@b.com"' in content.text or '"email": "a@b.com"' in content.text
+
+    async def test_dataclass_return_serialized_to_json(self) -> None:
+        mcp = AiohttpMCP()
+
+        @mcp.tool()
+        def get_user() -> UserDC:
+            return UserDC(name="Bob", email="b@b.com")
+
+        result = await mcp.call_tool("get_user", {})
+        assert len(result) == 1
+        content = result[0]
+        assert isinstance(content, TextContent)
+        assert '"name":"Bob"' in content.text or '"name": "Bob"' in content.text
+        assert '"email":"b@b.com"' in content.text or '"email": "b@b.com"' in content.text
+
+    async def test_basemodel_not_str_repr(self) -> None:
+        """Ensure BaseModel is not serialized via str() which produces a repr."""
+        mcp = AiohttpMCP()
+
+        @mcp.tool()
+        def get_user() -> UserModel:
+            return UserModel(name="Alice", email="a@b.com")
+
+        result = await mcp.call_tool("get_user", {})
+        content = result[0]
+        assert isinstance(content, TextContent)
+        # str(UserModel(...)) produces "name='Alice' email='a@b.com'" — must NOT appear
+        assert "name='Alice'" not in content.text
+
+    async def test_dataclass_not_str_repr(self) -> None:
+        """Ensure dataclass is not serialized via str() which produces a repr."""
+        mcp = AiohttpMCP()
+
+        @mcp.tool()
+        def get_user() -> UserDC:
+            return UserDC(name="Alice", email="a@b.com")
+
+        result = await mcp.call_tool("get_user", {})
+        content = result[0]
+        assert isinstance(content, TextContent)
+        # str(UserDC(...)) produces "UserDC(name='Alice', email='a@b.com')" — must NOT appear
+        assert "UserDC(" not in content.text
+
+    async def test_async_tool_with_basemodel_return(self) -> None:
+        mcp = AiohttpMCP()
+
+        @mcp.tool()
+        async def get_user() -> UserModel:
+            return UserModel(name="Async", email="async@b.com")
+
+        result = await mcp.call_tool("get_user", {})
+        content = result[0]
+        assert isinstance(content, TextContent)
+        assert "Async" in content.text
+        assert "async@b.com" in content.text
+
+
+# -- Tests: backward compatibility --
+
+
+class TestBackwardCompatibility:
+    """Ensure existing return types still work unchanged."""
+
+    async def test_str_return_unchanged(self) -> None:
+        mcp = AiohttpMCP()
+
+        @mcp.tool()
+        def echo(msg: str) -> str:
+            return msg
+
+        result = await mcp.call_tool("echo", {"msg": "hello"})
+        assert result[0].text == "hello"  # type: ignore[union-attr]
+
+    async def test_dict_return_unchanged(self) -> None:
+        mcp = AiohttpMCP()
+
+        @mcp.tool()
+        def data() -> dict[str, str]:
+            return {"key": "value"}
+
+        result = await mcp.call_tool("data", {})
+        assert '"key"' in result[0].text  # type: ignore[union-attr]
+
+    async def test_list_return_unchanged(self) -> None:
+        mcp = AiohttpMCP()
+
+        @mcp.tool()
+        def items() -> list[str]:
+            return ["a", "b"]
+
+        result = await mcp.call_tool("items", {})
+        assert len(result) == 2
+
+    async def test_tool_returning_str_even_with_model_annotation(self) -> None:
+        """If the tool has a model annotation but returns a string, it should still work."""
+        mcp = AiohttpMCP()
+
+        @mcp.tool()
+        def get_user() -> UserModel:
+            return "raw string fallback"  # type: ignore[return-value]
+
+        result = await mcp.call_tool("get_user", {})
+        content = result[0]
+        assert isinstance(content, TextContent)
+        # str is caught before the adapter path
+        assert content.text == "raw string fallback"


### PR DESCRIPTION
## Summary
Tools can now return Pydantic `BaseModel` or `dataclass` instances — they are automatically serialized to JSON and generate `outputSchema` in `tools/list` responses.

## Changes
- **Serialization**: `BaseModel`/`dataclass` return values are serialized via `TypeAdapter.dump_json()` instead of `str()` repr
- **`outputSchema`**: Auto-generated from the return type annotation in `tools/list` responses (MCP protocol 2025-06-18+, version-aware — older clients don't see it)
- **Backward compatible**: Plain return types (`str`, `dict`, `list`) behave exactly as before
- 16 new tests covering schema generation, JSON serialization, and backward compatibility
- Updated `CHANGELOG.md` and `README.md` with docs and examples